### PR TITLE
Add simple Latex typesetting engine for the dictionary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,3 @@
+typeset:	Makefile typeset.c
+	gcc -Wall -g -o typeset typeset.c
+

--- a/data/j.json
+++ b/data/j.json
@@ -16234,7 +16234,7 @@
             {
                 "id": "75b8309869",
                 "def": "a person who unpredictably displays two distinct and morally opposed personality traits",
-                "example": "The way they scream at me one minute and apologize the next—it's like they're Jekyll and Hyde!",
+                "example": "The way they scream at me one minute and apologize the next—it's like they're Jekyll and Hyde!",
                 "speech_part": "noun"
             }
         ],

--- a/data/n.json
+++ b/data/n.json
@@ -41752,7 +41752,7 @@
         "meanings": [
             {
                 "id": "7ca081e020",
-                "def": "a typographic symbol, № , used for denoting numbers",
+                "def": "a typographic symbol used for denoting numbers",
                 "example": "It is common in Europe to see a numero sign as opposed to an octothorpe.",
                 "speech_part": "noun"
             }

--- a/data/t.json
+++ b/data/t.json
@@ -75970,7 +75970,7 @@
             {
                 "id": "563223c076",
                 "def": "a natural spring of water at a temperature of 70 F or above",
-                "example": "The resort surrounded a thermal spring​ and allowed guests to relax in the rejuvenating waters.",
+                "example": "The resort surrounded a thermal spring and allowed guests to relax in the rejuvenating waters.",
                 "speech_part": "noun"
             }
         ],
@@ -104025,7 +104025,7 @@
             {
                 "id": "b4e163ba3e",
                 "def": "the feeling of being so happy, or laughing so much that you cry",
-                "example": "Seeing that hilarious video made me so 😂.",
+                "-example": "Seeing that hilarious video made me so 😂.",
                 "speech_part": "noun"
             }
         ]

--- a/template.tex
+++ b/template.tex
@@ -1,0 +1,80 @@
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+% Dictionary
+% LaTeX Template
+% Version 1.0 (20/12/14)
+%
+% This template has been downloaded from:
+% http://www.LaTeXTemplates.com
+%
+% Original author:
+% Vel (vel@latextemplates.com) inspired by a template by Marc Lavaud
+%
+% License:
+% CC BY-NC-SA 3.0 (http://creativecommons.org/licenses/by-nc-sa/3.0/)
+%
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%----------------------------------------------------------------------------------------
+%	PACKAGES AND OTHER DOCUMENT CONFIGURATIONS
+%----------------------------------------------------------------------------------------
+
+\documentclass[10pt,a4paper,twoside]{article} % 10pt font size, A4 paper and two-sided margins
+
+\usepackage[top=3.5cm,bottom=3.5cm,left=3.7cm,right=4.7cm,columnsep=30pt]{geometry} % Document margins and spacings
+
+\usepackage[utf8]{inputenc} % Required for inputting international characters
+\usepackage[T1]{fontenc} % Output font encoding for international characters
+
+\usepackage{palatino} % Use the Palatino font
+
+\usepackage{microtype} % Improves spacing
+
+\usepackage{multicol} % Required for splitting text into multiple columns
+
+\usepackage[bf,sf,center]{titlesec} % Required for modifying section titles - bold, sans-serif, centered
+
+\usepackage{fancyhdr} % Required for modifying headers and footers
+\fancyhead[L]{\textsf{\rightmark}} % Top left header
+\fancyhead[R]{\textsf{\leftmark}} % Top right header
+\renewcommand{\headrulewidth}{1.4pt} % Rule under the header
+\fancyfoot[C]{\textbf{\textsf{\thepage}}} % Bottom center footer
+\renewcommand{\footrulewidth}{1.4pt} % Rule under the footer
+\pagestyle{fancy} % Use the custom headers and footers throughout the document
+
+\newcommand{\entry}[4]{\markboth{#1}{#1}\textbf{#1}\ {(#2)}\ \textit{#3}\ $\bullet$\ {#4}}  % Defines the command to print each word on the page, \markboth{}{} prints the first word on the page in the top left header and the last word in the top right
+
+%----------------------------------------------------------------------------------------
+
+\begin{document}
+
+\input{a}
+\input{b}
+\input{c}
+\input{d}
+\input{e}
+\input{f}
+\input{g}
+\input{h}
+\input{i}
+\input{j}
+\input{k}
+\input{l}
+\input{m}
+\input{n}
+\input{o}
+\input{p}
+\input{q}
+\input{r}
+\input{s}
+\input{t}
+\input{u}
+\input{v}
+\input{w}
+\input{x}
+\input{y}
+\input{z}
+% LateX chokes on some of the unicode in this
+% \input{misc}
+
+%------------------------------------------------
+\end{document}

--- a/typeset.c
+++ b/typeset.c
@@ -1,0 +1,177 @@
+#include <stdio.h>
+#include <dirent.h>
+#include <stdlib.h>
+#include <strings.h>
+#include <string.h>
+
+#define MAX_FILE_SIZE (64*1024*1024)
+char data[MAX_FILE_SIZE];
+int data_len=0;
+
+char token[MAX_FILE_SIZE];
+char token_type[MAX_FILE_SIZE];
+char word_def[MAX_FILE_SIZE];
+char word_example[MAX_FILE_SIZE];
+char word_syns[MAX_FILE_SIZE];
+char word_type[MAX_FILE_SIZE];
+int token_len=0;
+int in_token=0;
+
+FILE *o=NULL;
+
+void emit_definition(void)
+{
+  fprintf(o,"\$\\bullet\$ \\ (%s) {%s.}\n",
+	 word_type,word_def);
+  if(word_example[0]) fprintf(o," \\textit{``%s''}\n",word_example);
+  if (word_syns[0]) {
+    fprintf(o," \\textsc{Synonyms:} %s\n",word_syns);
+  }
+  if (word_def) {
+    
+  }
+}
+
+void token_char(char c)
+{
+  if (in_token)
+    token[token_len++]=c;
+}
+
+void token_start(int depth)
+{
+  in_token=1;
+  token_len=0;
+}
+
+void token_end(int depth, int colonP)
+{
+  token[token_len]=0;
+  if (colonP) strcpy(token_type,token);
+  if ((!colonP)&&(depth==3)) {
+    // Remember field
+    if (!strcmp(token_type,"def")) strcpy(word_def,token);
+    else if (!strcmp(token_type,"example")) strcpy(word_example,token);
+    else if (!strcmp(token_type,"speech_part")) strcpy(word_type,token);
+    else if (!strcmp(token_type,"speech\\_part")) strcpy(word_type,token);
+    else if (!strcmp(token_type,"synonyms")) strcpy(word_syns,token);
+    else {
+      //      fprintf(stderr,"Encountered unknown token type '%s'\n",token);
+      //      exit(-1);
+    }
+  }
+  //   printf("'%s' (%s) @ %d, %d\n",token,token_type,depth,colonP);
+  if ((!colonP)&&(depth==2)&&(!strcmp(token_type,"word")))
+    {
+      fprintf(o,"\\par \\markboth{%s}{%s}\\textbf{%s}\n",
+	     token,token,token);
+    }
+
+  
+  token_len=0;
+  in_token=0;
+}
+
+void parse_file(FILE *f)
+{
+  int depth=0;
+  
+  data_len=fread(data,1,MAX_FILE_SIZE,f);
+  fprintf(stderr,"%d bytes\n",data_len);
+  for(int i=0;i<data_len;i++) {
+    switch(data[i]) {
+    case '{':
+      depth++;
+      if (depth==3) {
+	word_example[0]=0;
+	word_type[0]=0;
+	word_syns[0]=0;
+	word_def[0]=0;
+      }
+      break;
+    case '}':
+      if (depth) depth--;
+      if (depth==2) {
+	emit_definition();
+      }
+      break;
+    case '$': case '_': case '%': case '^': case '@': case '#': case '&':
+      token_char('\\');
+      token_char(data[i]);
+      break;
+    case '\"':
+      if (data[i+1]==':') {
+	token_end(depth,1);
+	i++;
+      } else {
+	if (!token_len)
+	  token_start(depth);
+	else token_end(depth,0);
+      }
+      break;
+    case '\\':
+      if (data[i+1]=='"') {
+	// Escaped quote
+	token_char(data[i+1]);
+	i++;
+      } else if (data[i+1]=='n') {
+	// \n
+	token_char('\n');
+	i++;
+      } else {
+	fprintf(stderr,"Illegal escape sequence \\%c\n",data[i+1]);
+	exit(-3);
+      }
+      break;
+    default:
+      token_char(data[i]);
+      break;
+    }
+  }
+}
+
+int main(int argc,char **argv)
+{
+
+  DIR *d=opendir("data");
+  if (!d) {
+    fprintf(stderr,"Could not open data directory for reading.\n");
+    exit(-1);
+  }
+
+  struct dirent *de;
+
+  while((de=readdir(d))!=NULL) {
+    if (strlen(de->d_name)>strlen(".json")) {
+      char name[1024];
+      strcpy(name,de->d_name);
+      name[strlen(de->d_name)-5]=0;
+      
+      char filename[1024];
+      snprintf(filename,1024,"data/%s",de->d_name);
+      FILE *f=fopen(filename,"r");
+      if (!f) {
+	fprintf(stderr,"ERROR: Could not read '%s'\n",filename);
+	exit(-3);
+      }
+      snprintf(filename,1024,"%s.tex",name);
+      o=fopen(filename,"w");
+      fprintf(o,
+	      "\\section*{%s}\n"
+	      "\\begin{multicols}{2}\n",
+	      name);	      
+      
+      parse_file(f);
+
+      fprintf(o,"\\end{multicols}\n");
+      fprintf(o,"\\clearpage\n");
+      
+      fprintf(stderr,"Scanning %s\n",de->d_name);
+      
+      fclose(f);
+    }
+  }
+
+  closedir(d);
+  
+}


### PR DESCRIPTION
These changes make it possible to typeset a (admittedly rather crude) PDF from the dictionary.
(This was created because our kids needed a physical dictionary for a school exercise, but we are living in the middle of the Australian Outback, where bookstores aren't particularly common).
I did have to munge a few entries to get rid of (mostly) stray unicode symbols. The only real victim is the numero entry, and that the misc.json file isn't included in the typesetting because it is full of strange unicode symbols.  It should be possible to get latex to support them, but I don't have the time to attack that today.